### PR TITLE
Strawman counterproposal

### DIFF
--- a/PushPop.md
+++ b/PushPop.md
@@ -1,0 +1,112 @@
+# Text Format Idea: Explicit Push and Pop
+
+Push and pop are an idea for visually splitting up expression trees. Push
+and pop connect subtrees to their parents, allowing them to be written
+separately in the text syntax, but still be part of the same conceptual tree
+in the wasm semantics, and in the wasm binary format.
+
+Here's the proposed text syntax for the `Q_rsqrt` example from TextFormat.md,
+but with `push` and `pop`:
+
+```
+   function $Q_rsqrt ($0:f32) : (f32) {
+     var $1:f32
+     $1 = f32.reinterpret/i32 (1597463007 - ((i32.reinterpret/f32 $0) >> 1))
+     push:0 $0 = $0 * 0x1p-1
+     $1 = $1 * (0x1.8p0 - $1 * pop:0 * $1)
+     $1 * (0x1.8p0 - $1 * $0 * $1)
+   }
+```
+
+Note that the original version has a `set_local` buried in the middle of a
+tree, making it easy for a human to miss. Humans wouldn't write code that
+way, but in wasm, compilers are *incentivised* to write it that way, because
+it reduces code size. It's going to happen a lot, and the push/pop mechanism
+gives us a way to make this more readable in many cases.
+
+
+## Discussion
+
+In a normal programming language, the preferred way to split up a large
+expression tree would be to simply assign some subtrees to their own local
+variables. Of course compilers can optimize them away as needed, so there's
+no reason not to do this.
+
+However in wasm, introducing locals increases code size, so
+compilers producing wasm aren't going to do that. There will be a lot of code
+in the wild with very large monolithic trees, because compilers will be writing
+code that way to minimize code size. And, binary->text translation can't
+introduce local variables, because that would make binary->text->binary lossy.
+
+The solution proposed here: `push` and `pop`. `push` pushes subtrees onto a
+conceptual stack, and `pop` pops them and conceptually connects them to the
+tree that that point. It's important to realize that this is purely a
+text-format device. These constructs just exist to build trees. In the abstract
+wasm semantics and in the binary format, the trees just exist in monolithic
+form.
+
+Now there's a question: how should a binary->text translator decide where to
+split up trees? It turns out, we can let binary->text translators choose what
+they think is best in their situation:
+
+ - Split trees at `set_local` operators. This is what the examples here do,
+   and it's balance delivering readability while still keeping the code
+   fairly concise.
+ - Split trees at nodes with "side effects" (call, `store`, etc.). This can
+   additionally aid in debugging, as one can clearly see where the side effects
+   occur and step through them.
+ - Split trees at *all* points. This essentially puts every instruction on its
+   own line, which may sometimes be useful for single-step debugging scenarios,
+   or for compiler writers.
+ - Don't split trees at all. Maximum bushiness.
+
+Each of these strategies map back to the same binary format. A single text
+format can support a wide variety of use cases, because binary->text
+translators can split up trees to fit the need at hand.
+
+
+## Details
+
+Expressions containing multiple pops perform their pops right-to-left. This is
+surprising at first, but it makes sense when you look at wasm's evaluation order.
+For example:
+
+```
+   push:0 call $foo()
+   push:1 call $bar()
+   call $qux(pop:0, pop:1)
+```
+
+Clearly, this syntax should evaluate the call to `$foo` before the call to
+`$bar`. And in the wasm semantics, the call to `$qux` evaluates its operands in
+the order they appear. Both of these principles are completely intuitive. Put
+together as they are here, they imply that the first pop corresponds to the
+first push, which effectively means that the pops happen right-to-left.
+
+The `:0` and `:1` are stack-depth indicators, which can be useful in pairing
+up pushes with their corresponding pops.
+
+Some additional rules governing push and pop are:
+
+ - Pushed expressions must be popped within the same block as the push.
+ - Stack-depth indicators start at 0 at the beginning of each block.
+ - Sequences of trees tied together with push and pop must be contiguous.
+   Arbitrary blocks can be placed in the middle of trees, but their return value
+   has to be consumed by some node in the tree.
+
+These rules reflect how the current wasm binary format works. If there are
+changes to wasm, these rules would change accordingly.
+
+
+## Answers to anticipated questions
+
+Q: How about replacing push/pop with something more flexible?
+
+A: Push/pop as described here are meant to be a direct reflection of WebAssembly
+   itself. For example, it would be convenient to replace `push` with
+   something that would allow a value to be used multiple times. However,
+   push/pop are representing expression tree edges in WebAssembly, which
+   can only have a single definition and a single use. The way to use a value
+   multiple times in WebAssembly is to use `set_local` and `get_local`.
+
+

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -236,7 +236,7 @@ And here's the proposed text syntax:
 ```
    function $Q_rsqrt($0:f32) : (f32) {
      $1:f32
-     $1 = f32.reinterpret'i32 (1597463007 - ((i32.reinterpret'f32 $0) >> 1))
+     $1 = f32.reinterpret'i32(1597463007 - (i32.reinterpret'f32($0) >> 1))
      $1 = $1 * (0x1.8p0 - $1 * ($0 = $0 * 0x1p-1) * $1)
      $1 * (0x1.8p0 - $1 * $0 * $1)
    }
@@ -343,32 +343,32 @@ conditions use `?`. The following is a table of special syntax:
 
 ## Control flow operators ([described here](https://github.com/WebAssembly/design/blob/master/AstSemantics.md))
 
-| Name       | Syntax                   | Examples 
-| ---------- | ------------------------ | -------- 
-| `block`    | :*label*                 | `{ br a; :a }`
-| `loop`     | `loop` *label* `{` … `}` | `loop a { br a }`
+| Name       | Syntax                     | Examples 
+| ---------- | -------------------------- | -------- 
+| `block`    | :*label*                   | `{ br a; :a }`
+| `loop`     | `loop` *label* `{` … `}`   | `loop a { br a }`
 | `if`       | `if (`*expr*`)` `{` *expr** `}` | `if ($x) { $f($x) }`
 | `if_else`  | `if (`*expr*`)` `{` *expr** `} else {` *expr** `}` | `if (0) { 1 } else { 2 }`
 | `select`   | `select` *expr* `:` *expr* `?` *expr*`)` | `select 1 : 2 ? $x < $y`
-| `br`       | `br` *label*               | `br a`
-| `br_if`    | `br_if` *label* `?` *expr* | `br_if a ? $x < $y`
+| `br`       | `br` *label* [=> $result]    | `br a`, `br a => $x`
+| `br_if`    | `br_if` *label* `(if` *expr*`)` [`=>` *expr*] | `br a (if $x < $y) => 0`
 | `br_table` | `br_table {` *case-label* `,` … `,` *default-label*] `} from` *expr* | `br_table [a, b, c] : $x`
 
 (TODO: as above, are the `?`s too cute?)
 
 ## Basic operators ([described here](https://github.com/WebAssembly/design/blob/master/AstSemantics.md#constants))
 
-| Name | Syntax | Example
-| ---- | ---- | ---- |
-| `i32.const` | … | `234`, `0xfff7`
-| `i64.const` | … | `234`, `0xfff7`
-| `f64.const` | … | `0.1p2`, `infinity`, `nan:0x789`
-| `f32.const` | … | `0.1p2`, `infinity`, `nan:0x789`
-| `get_local` | *name* | `$x + 1`
+| Name        | Syntax      | Example
+| ----------- | ----------- | ---- |
+| `i32.const` | see example | `234`, `0xfff7`
+| `i64.const` | see example | `234L`, `0xfff7L`
+| `f64.const` | see example | `0.1p2`, `@inf`, `@nan'0x789`
+| `f32.const` | see example | `0.1p2f`, `@inf_f`, `@nan'0x789`
+| `get_local` | *name* (including the `$`) | `$x`
 | `set_local` | *name* `=` *expr* | `$x = 1`
-| `call` | `call` *name* `(`*expr* `,` … `)` | `call $min(0, 2)`
-| `call_import` | `call_import` *name* `(`*expr* `,` … `)` | `call_import $max(0, 2)`
-| `call_indirect` | `call_indirect` *signature-name* `[` *expr* `] (`*expr* `,` … `)` | `call_indirect $foo [1] $min(0, 2)`
+| `call`      | *name* `(`*expr* `,` … `)` | `$min(0, 2)`
+| `call_import` | `$` *name* `(`*expr* `,` … `)` | `$$max(0, 2)`
+| `call_indirect` | *expr* `::` *signature-name* [`[` *expr* `]`] `(`*expr* `,` … `)` | `$func::$signature(0, 2)`
 
 ## Memory-related operators ([described here](https://github.com/WebAssembly/design/blob/master/AstSemantics.md#linear-memory-accesses))
 
@@ -376,9 +376,9 @@ conditions use `?`. The following is a table of special syntax:
 | ---- | ---- | ---- |
 | *memory-immediate* | `[` *base-expression* `,` *offset* `]` | `[$base, 4]`
 | `i32.load8_s` | `i32.load8_s [` *base-expression* `, +` *offset-immediate* `]` | `i32.load8_s [$base, +4]`
-| `i32.load8_s` | `i32.load8_s [` *base-expression* `, +` *offset-immediate* `]:align=` *align* | `i32.load8_s [$base, +4]:align=2`
+| `i32.load8_s` | `i32.load8_s [` *base-expression* `, +` *offset-immediate* `, align ` *align* `]` | `i32.load8_s [$base, +4, align 2]`
 | `i32.store8` | `i32.store8 [` *base-expression* `, +` *offset-immediate* `]`, *expr* | `i32.store8 [$base, +4], $value`
-| `i32.store8` | `i32.store8 [` *base-expression* `, +` *offset-immediate* `]:align=` *align* `,` *expr* | `i32.store8 [$base, +4]:align=2, $value`
+| `i32.store8` | `i32.store8 [` *base-expression* `, +` *offset-immediate* `, align ` *align* `]` `=` *expr* | `i32.store8 [$base, +4, align 2] = $value`
 
 The other forms of `load` and `store` are similar.
 

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -215,8 +215,7 @@ And here's the proposed text syntax:
    function $Q_rsqrt ($0:f32) : (f32) {
      var $1:f32
      $1 = f32.reinterpret/i32 (1597463007 - ((i32.reinterpret/f32 $0) >> 1))
-     push:0 $0 = $0 * 0x1p-1
-     $1 = $1 * (0x1.8p0 - $1 * pop:0 * $1)
+     $1 = $1 * (0x1.8p0 - $1 * ($0 = $0 * 0x1p-1) * $1)
      $1 * (0x1.8p0 - $1 * $0 * $1)
    }
 ```
@@ -224,19 +223,6 @@ And here's the proposed text syntax:
 This shows off the compactness of infix operators with overloading. In the
 s-expression syntax, these expressions are quite awkward to read, and this
 isn't even a very big example. But the text syntax here is very short.
-
-This also introduces the push and pop mechanism for splitting up expression
-trees. Push and pop connect subtrees to their parents, allowing them to be
-written separately in the text syntax, but still be part of the same
-conceptual tree in the wasm semantics, and in the wasm binary format.
-
-In particular, note that the s-expression version has a `set_local` buried in
-the middle of a tree, making it easy for a human to miss. Humans wouldn't write
-code that way, but in wasm, compilers are *incentivised* to write it that way,
-because it reduces code size. It's going to happen a lot, and the push/pop
-mechanism gives us a way to make this more readable in many cases.
-
-See [below](#pushpop) for more information.
 
 ### Labels
 
@@ -301,7 +287,6 @@ nesting of `br_table` to be printed in a relatively flat manner:
 representing the following in nested form:
 
 ```
-
   (block $default
     (block $green
       (block $yellow
@@ -321,89 +306,6 @@ representing the following in nested form:
 
 `br_table`s can have large numbers of labels, so this feature allows us to
 avoid very deep nesting in many cases.
-
-
-## Push and pop
-
-Note: Push/pop is a particularly experimental piece of this proposal. The
-proposal works without it, and the initial Firefox implementation does not
-include it. It makes some kinds of code more readable, and provides a
-consistent way to support a spectrum of views on WebAssembly ranging from
-one-instruction-per-line to maximum nesting, however it is unfamiliar many
-people, and it does come with some non-obvious limitations, so its overall
-value is unclear.
-
-That said, here's the idea, for what it's worth:
-
-In a normal programming language, the preferred way to split up a large
-expression tree would be to simply assign some subtrees to their own local
-variables. Of course compilers can optimize them away as needed, so there's
-no reason not to do this.
-
-However in wasm, introducing locals increases code size, so
-compilers producing wasm aren't going to do that. There will be a lot of code
-in the wild with very large monolithic trees, because compilers will be writing
-code that way to minimize code size. And, binary->text translation can't
-introduce local variables, because that would make binary->text->binary lossy.
-
-The solution proposed here: `push` and `pop`. `push` pushes subtrees onto a
-conceptual stack, and `pop` pops them and conceptually connects them to the
-tree that that point. It's important to realize that this is purely a
-text-format device. These constructs just exist to build trees. In the abstract
-wasm semantics and in the binary format, the trees just exist in monolithic
-form.
-
-Now there's a question: how should a binary->text translator decide where to
-split up trees? It turns out, we can let binary->text translators choose what
-they think is best in their situation:
-
- - Split trees at `set_local` operators. This is what the examples here do,
-   and it's balance delivering readability while still keeping the code
-   fairly concise.
- - Split trees at nodes with "side effects" (call, `store`, etc.). This can
-   additionally aid in debugging, as one can clearly see where the side effects
-   occur and step through them.
- - Split trees at *all* points. This essentially puts every instruction on its
-   own line, which may sometimes be useful for single-step debugging scenarios,
-   or for compiler writers.
- - Don't split trees at all. Maximum bushiness.
-
-Each of these strategies map back to the same binary format. A single text
-format can support a wide variety of use cases, because binary->text
-translators can split up trees to fit the need at hand.
-
-
-## Push and pop details
-
-Expressions containing multiple pops perform their pops right-to-left. This is
-surprising at first, but it makes sense when you look at wasm's evaluation order.
-For example:
-
-```
-   push:0 call $foo()
-   push:1 call $bar()
-   call $qux(pop:0, pop:1)
-```
-
-Clearly, this syntax should evaluate the call to `$foo` before the call to
-`$bar`. And in the wasm semantics, the call to `$qux` evaluates its operands in
-the order they appear. Both of these principles are completely intuitive. Put
-together as they are here, they imply that the first pop corresponds to the
-first push, which effectively means that the pops happen right-to-left.
-
-The `:0` and `:1` are stack-depth indicators, which can be useful in pairing
-up pushes with their corresponding pops.
-
-Some additional rules governing push and pop are:
-
- - Pushed expressions must be popped within the same block as the push.
- - Stack-depth indicators start at 0 at the beginning of each block.
- - Sequences of trees tied together with push and pop must be contiguous.
-   Arbitrary blocks can be placed in the middle of trees, but their return value
-   has to be consumed by some node in the tree.
-
-These rules reflect how the current wasm binary format works. If there are
-changes to wasm, these rules would change accordingly.
 
 
 ## Operators with special syntax
@@ -558,16 +460,6 @@ Q: Why not permit optional semicolons?
 A: We don't want people arguing over which way is better. If we don't forbid
    semicolons, the next best option would be to require semicolons. I've
    subjectively chosen to forbid semicolons for now.
-
-
-Q: How about replacing push/pop with something more flexible?
-
-A: Push/pop as described here are meant to be a direct reflection of WebAssembly
-   itself. For example, it would be convenient to replace `push` with
-   something that would allow a value to be used multiple times. However,
-   push/pop are representing expression tree edges in WebAssembly, which
-   can only have a single definition and a single use. The way to use a value
-   multiple times in WebAssembly is to use `set_local` and `get_local`.
 
 
 # Debug symbol integration

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -280,7 +280,6 @@ nesting of `br_table` to be printed in a relatively flat manner:
   $green:
       // ...
   $default:
-      // ...
   }
 ```
 
@@ -307,6 +306,8 @@ representing the following in nested form:
 `br_table`s can have large numbers of labels, so this feature allows us to
 avoid very deep nesting in many cases.
 
+Note that when a label appears just before the closing `}`, it doesn't introduce
+a new block; it just provides a name for the enclosing block's label.
 
 ## Operators with special syntax
 

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -325,13 +325,25 @@ avoid very deep nesting in many cases.
 
 ## Push and pop
 
-Normally, the preferred way to split up a large expression tree would be to
-simply assign some subtrees to their own local variables. Of course compilers
-can optimize them away as needed.
+Note: Push/pop is a particularly experimental piece of this proposal. The
+proposal works without it, and the initial Firefox implementation does not
+include it. It makes some kinds of code more readable, and provides a
+consistent way to support a spectrum of views on WebAssembly ranging from
+one-instruction-per-line to maximum nesting, however it is unfamiliar many
+people, and it does come with some non-obvious limitations, so its overall
+value is unclear.
 
-However, in wasm, introducing locals like that increases code size, so
+That said, here's the idea, for what it's worth:
+
+In a normal programming language, the preferred way to split up a large
+expression tree would be to simply assign some subtrees to their own local
+variables. Of course compilers can optimize them away as needed, so there's
+no reason not to do this.
+
+However in wasm, introducing locals increases code size, so
 compilers producing wasm aren't going to do that. There will be a lot of code
-in the wild with very large monolithic trees. Binary->text translation can't
+in the wild with very large monolithic trees, because compilers will be writing
+code that way to minimize code size. And, binary->text translation can't
 introduce local variables, because that would make binary->text->binary lossy.
 
 The solution proposed here: `push` and `pop`. `push` pushes subtrees onto a

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -35,13 +35,26 @@ represented as hexadecimal floating-point as specified by the C99 standard, whic
 IEEE-754-2008 section 5.12.3 also specifies. The textual format may be improved to also
 support more human-readable representations, but never at the cost of accurate representation.
 
-# Official Text Format
+# ~~Official~~*Experimental* Text Format
 
-## Warning: this is an experiment.
+## This is an experiment!
 
-This document has not been submitted to any official WebAssembly forum.
-It is not known at this time whether it ever will be, and if it is, it
-may be with significant changes.
+This document is a sketch of a possible Text Format proposal for WebAssembly to
+use for the "View Source" functionality in browsers. WebAssembly looks enough
+like a programming language that it tends to activate our programmer intuitions
+about syntax, but it differs from normal programming languages in numerous
+respects, so we don't fully trust our intuitions.
+
+So, we're sketching something up, and building a trial implementation of it in
+Firefox, so that we can try it out on real code in a real browser setting, to
+see if it actually "works" in practice. Maybe we'll like it and propose it to
+the official WebAssembly project. Maybe it'll need changes. Or maybe it'll
+totally flop and we'll drop it and pursue something completely different!
+
+Comments, questions, suggestions, and reactions are welcome on
+[this repo's issue tracker](https://github.com/sunfishcode/design/issues) for
+the moment. As the experiment progresses, we may shift to other discussion
+forums, but for now we're keeping it simple.
 
 
 ## Philosophy:

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -5,26 +5,20 @@ The purpose of this text format is to support:
   source can be viewed) in a natural way.
 * Presentation in browser development tools when source maps aren't present
   (which is necessarily the case with [the Minimum Viable Product (MVP)](MVP.md)).
-* Writing WebAssembly code directly for reasons including pedagogical,
-  experimental, debugging, optimization, and testing of the spec itself.
+* Working with WebAssembly code directly for reasons including pedagogical,
+  experimental, debugging, profiling, optimization, and testing of the spec
+  itself.
 
 The text format is equivalent and isomorphic to the [binary format](BinaryEncoding.md).
 
-The text format will be standardized, but only for tooling purposes:
-* Compilers will support this format for `.S` and inline assembly.
-* Debuggers and profilers will present binary code using this textual format.
-* Browsers will not parse the textual format on regular web content in order to
-  implement WebAssembly semantics.
+The text format will be standardized, but only for tooling purposes; browsers
+will not parse the textual format on regular web content in order to implement
+WebAssembly semantics.
 
-Given that the code representation is actually an
-[Abstract Syntax Tree](AstSemantics.md), the syntax would contain nested
-statements and expressions (instead of the linear list of instructions most
-assembly languages have).
-
-There is no requirement to use JavaScript syntax; this format is not intended to
-be evaluated or translated directly into JavaScript. There may also be
+The text format does not use JavaScript syntax; it is not intended to
+be evaluated or translated directly into JavaScript. There are also
 substantive reasons to use notation that is different than JavaScript (for
-example, WebAssembly has a 32-bit integer type, and it should be represented
+example, WebAssembly has a 32-bit integer type, and it is represented
 in the text format, since that is the natural thing to do for WebAssembly,
 regardless of JavaScript not having such a type). On the other hand,
 when there are no substantive reasons and the options are basically
@@ -43,37 +37,498 @@ support more human-readable representations, but never at the cost of accurate r
 
 # Official Text Format
 
-WebAssembly currently doesn't have a final, official, text format. As detailed above the
-main purpose of the text format will be for human consumption, feedback from humans on
-readability will therefore factor into standardizing a text format.
+## Philosophy:
 
-There are, however, prototype syntaxes which are used to bring up WebAssembly: it's easier
-to develop using a text format than it is with a binary format, even if the ultimate
-WebAssembly format will be binary. Most of these prototypes use [s-expressions][] because they
-can easily represent expression trees and [ASTs](AstSemantics.md) (as opposed to CFGs)
-and don't have much of a syntax to speak of (avoiding syntax bikeshed discussions).
+ - Use JS-style sensibilities when there aren't reasons otherwise.
+ - It's a compiler target, not a programming language, but readability still counts.
 
-  [s-expressions]: https://en.wikipedia.org/wiki/S-expression
 
-Here are some of these prototypes. Keep in mind that these *aren't* official, and the final
-official format may look entirely different:
+## High-level summary:
 
-* [Prototype specification][] consumes an s-expression syntax.
-* [WAVM backend][] consumes compatible s-expressions.
-* [sexpr-wasm prototype][] consumes compatible s-expressions, and works closely with the [V8 prototype][].
-* [LLVM backend][] (the `CHECK:` parts of these tests) emits compatible s-expressions.
-* [ilwasm][] emits compatible s-expressions.
-* [wassembler][] consumes a different syntax, and works closely with the [V8 prototype][].
-* [binaryen][] can consume compatible s-expressions.
+ - Curly braces for function bodies, blocks, etc., `/* */`-style and `//`-style
+   comments, and whitespace is not significant. Also, no semicolons.
+   (TODO: Should `/* */`-style comments nest properly?)
 
-  [prototype specification]: https://github.com/WebAssembly/spec/tree/master/ml-proto/test
-  [LLVM backend]: https://github.com/llvm-mirror/llvm/tree/master/test/CodeGen/WebAssembly
-  [WAVM backend]: https://github.com/AndrewScheidecker/WAVM/tree/master/Test
-  [wassembler]: https://github.com/ncbray/wassembler/tree/master/demos
-  [V8 prototype]: https://github.com/WebAssembly/v8-native-prototype
-  [ilwasm]: https://github.com/WebAssembly/ilwasm
-  [sexpr-wasm prototype]: https://github.com/WebAssembly/sexpr-wasm-prototype
-  [binaryen]: https://github.com/WebAssembly/binaryen
+ - `get_local` looks like a simple reference; `set_local` looks like an
+   assignment. Constants use a simple literal syntax. This makes wasm's most
+   frequent opcodes very concise.
+
+ - Infix syntax for arithmetic, with simple overloading. Explicit grouping via
+   parentheses. Concise and familiar with JS and others. (TODO: Use C/JS-style
+   operator precedence, or fix
+   [an old mistake](http://www.lysator.liu.se/c/dmr-on-or.html)?)
+
+ - Prefix syntax with comma-separated operands for all other operators. For less
+   frequent opcodes, prefer just presenting operator names, so that they're easy
+   to identify.
+
+ - Typescript-style `name : type` declarations.
+
+ - Parentheses around call arguments, eg. `call $functionname(arg, arg, arg)`,
+   and `if` conditions, eg. `if ($condition) { call $then() } else { call $else() }`,
+   because they're familiar to many people and not too intrusive.
+
+ - Allow highly complex trees to be syntactically split up into readable parts.
+
+ - Put labels "where they go".
+
+
+## Examples:
+
+### Basics
+
+```
+  function $fac-opt ($a:i64) : (i64) {
+    var $x:i64
+    $x = 1
+    {
+      br_if $end ? $a <s 2
+      loop $loop {
+        $x = $x * $a
+        $a = $a + -1
+        br_if $loop ? $a >s 1
+      }
+      $end:
+    }
+    $x
+  }
+```
+
+(hand-translated from [fac.wast](https://github.com/WebAssembly/spec/blob/master/ml-proto/test/fac.wast))
+
+The function return type has parentheses for symmetry with the parameter types,
+anticipating adding multiple return values to wasm in the future.
+
+The curly braces around the function body are not a `block` node; they are part
+of the function syntax, reflecting how function bodies in wasm are block-like.
+
+The last expression of the function body here acts as its return value. This
+works in all block-like constructs (`block`, function body, `if`, etc.)
+
+`>s` means *signed* greater-than. explicit unsigned or signed operators will be
+suffixed with 'u' or 's', respectively.
+
+The `$` sigil on user names cleanly ensures that they never collide with wasm
+keywords, present or future.
+
+`br_if` uses a question mark to announce the condition operand. `select` does
+also. (TODO: Is this too cute?)
+
+### Linear memory addresses
+
+```
+  function $test_redundant_load () : (i32) {
+    i32.load [8,+0]
+    f32.store [5,+0], -0x0p0
+    i32.load [8,+0]
+  }
+```
+
+(hand-translated from [memory_redundancy.wast](https://github.com/WebAssembly/spec/blob/master/ml-proto/test/memory_redundancy.wast))
+
+Addresses are printed as `[base,+offset]`. It could be shortened to `[base]` when
+there is no offset; I made the offset explicit above just to illustrate the syntax.
+There can also be an optional `:align=…` for non-natural alignments.
+
+### A slightly larger example:
+
+Here's some C code:
+
+```
+  float Q_rsqrt(float number)
+  {
+      long i;
+      float x2, y;
+      const float threehalfs = 1.5F;
+
+      x2 = number * 0.5F;
+      y  = number;
+      i  = *(long *) &y;
+      i  = 0x5f3759df - (i >> 1);
+      y  = *(float *) &i;
+      y  = y * (threehalfs - (x2 * y * y));
+      y  = y * (threehalfs - (x2 * y * y));
+
+      return y;
+  }
+```
+
+Here's the corresponding LLVM wasm backend output + binaryen + slight tweaks:
+
+```
+  (func $Q_rsqrt (param $0 f32) (result f32)
+    (local $1 f32)
+    (set_local $1
+      (f32.reinterpret/i32
+        (i32.sub
+          (i32.const 1597463007)
+          (i32.shr_s
+            (i32.reinterpret/f32
+              (get_local $0))
+            (i32.const 1)))))
+    (set_local $1
+      (f32.mul
+        (get_local $1)
+        (f32.sub
+          (f32.const 1.5)
+          (f32.mul
+            (get_local $1)
+            (f32.mul
+              (get_local $1)
+              (set_local $0
+                (f32.mul
+                  (get_local $0)
+                  (f32.const 0.5))))))))
+    (f32.mul
+      (get_local $1)
+      (f32.sub
+        (f32.const 1.5)
+        (f32.mul
+          (get_local $1)
+          (f32.mul
+            (get_local $0)
+            (get_local $1)))))
+   )
+```
+
+And here's the proposed text syntax:
+
+```
+   function $Q_rsqrt ($0:f32) : (f32) {
+     var $1:f32
+     $1 = f32.reinterpret/i32 (1597463007 - ((i32.reinterpret/f32 $0) >> 1))
+     push:0 $0 = $0 * 0x1p-1
+     $1 = $1 * (0x1.8p0 - $1 * pop:0 * $1)
+     $1 * (0x1.8p0 - $1 * $0 * $1)
+   }
+```
+
+This shows off the compactness of infix operators with overloading. In the
+s-expression syntax, these expressions are quite awkward to read, and this
+isn't even a very big example. But the text syntax here is very short.
+
+This also introduces the push and pop mechanism for splitting up expression
+trees. Push and pop connect subtrees to their parents, allowing them to be
+written separately in the text syntax, but still be part of the same
+conceptual tree in the wasm semantics, and in the wasm binary format.
+
+In particular, note that the s-expression version has a `set_local` buried in
+the middle of a tree, making it easy for a human to miss. Humans wouldn't write
+code that way, but in wasm, compilers are *incentivised* to write it that way,
+because it reduces code size. It's going to happen a lot, and the push/pop
+mechanism gives us a way to make this more readable in many cases.
+
+See [below](#pushpop) for more information.
+
+### Labels
+
+Excerpt from labels.wast:
+
+```
+  (func $loop3 (result i32)
+    (local $i i32)
+    (set_local $i (i32.const 0))
+    (loop $exit $cont
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if (i32.eq (get_local $i) (i32.const 5))
+        (br $exit (get_local $i))
+      )
+      (get_local $i)
+    )
+  )
+```
+
+Corresponding proposed text syntax:
+
+```
+  function $loop3 () : (i32) {
+    var $i:i32
+    $i = 0
+    loop $cont {
+      $i = $i + 1
+      if ($i == 5) {
+        br $exit, $i
+      }
+    $exit:
+    }
+  }
+```
+
+Note that the curly braces are part of the `if`, rather than introducing a
+block. This reflects how `if` essentially provides `block`-like capabilities
+in the wasm binary format.
+
+### Nested blocks
+
+Label definitions, like the `$exit:` above, introduce additional blocks nested
+within the nearest `{`, without requiring their own `{`. This allows the deep
+nesting of `br_table` to be printed in a relatively flat manner:
+
+```
+  {
+    br_table [$red, $orange, $yellow, $green], $default, $index
+    $red:
+      // ...
+    $orange:
+      // ...
+    $yellow:
+      // ...
+    $green:
+      // ...
+    $default:
+      // ...
+  }
+```
+
+representing the following in nested form:
+
+```
+
+  (block $default
+    (block $green
+      (block $yellow
+        (block $orange
+          (block $red
+            (br_table [$red, $orange, $yellow, $green] $default (get_local $index))
+          )
+          // ...
+        )
+        // ...
+      )
+      // ...
+    )
+    // ...
+  )
+```
+
+`br_table`s can have large numbers of labels, so this feature allows us to
+avoid very deep nesting in many cases.
+
+
+## Push and pop
+
+Normally, the preferred way to split up a large expression tree would be to
+simply assign some subtrees to their own local variables. Of course compilers
+can optimize them away as needed.
+
+However, in wasm, introducing locals like that increases code size, so
+compilers producing wasm aren't going to do that. There will be a lot of code
+in the wild with very large monolithic trees. Binary->text translation can't
+introduce local variables, because that would make binary->text->binary lossy.
+
+The solution proposed here: `push` and `pop`. `push` pushes subtrees onto a
+conceptual stack, and `pop` pops them and conceptually connects them to the
+tree that that point. It's important to realize that this is purely a
+text-format device. These constructs just exist to build trees. In the abstract
+wasm semantics and in the binary format, the trees just exist in monolithic
+form.
+
+Now there's a question: how should a binary->text translator decide where to
+split up trees? It turns out, we can let binary->text translators choose what
+they think is best in their situation:
+
+ - Split trees at `set_local` operators. This is what the examples here do,
+   and it's balance delivering readability while still keeping the code
+   fairly concise.
+ - Split trees at nodes with "side effects" (call, `store`, etc.). This can
+   additionally aid in debugging, as one can clearly see where the side effects
+   occur and step through them.
+ - Split trees at *all* points. This essentially puts every instruction on its
+   own line, which may sometimes be useful for single-step debugging scenarios,
+   or for compiler writers.
+ - Don't split trees at all. Maximum bushiness.
+
+Each of these strategies map back to the same binary format. A single text
+format can support a wide variety of use cases, because binary->text
+translators can split up trees to fit the need at hand.
+
+
+## Push and pop details
+
+Expressions containing multiple pops perform their pops right-to-left. This is
+surprising at first, but it makes sense when you look at wasm's evaluation order.
+For example:
+
+```
+   push:0 call $foo()
+   push:1 call $bar()
+   call $qux(pop:0, pop:1)
+```
+
+Clearly, this syntax should evaluate the call to `$foo` before the call to
+`$bar`. And in the wasm semantics, the call to `$qux` evaluates its operands in
+the order they appear. Both of these principles are completely intuitive. Put
+together as they are here, they imply that the first pop corresponds to the
+first push, which effectively means that the pops happen right-to-left.
+
+The `:0` and `:1` are stack-depth indicators, which can be useful in pairing
+up pushes with their corresponding pops.
+
+Some additional rules governing push and pop are:
+
+ - Pushed expressions must be popped within the same block as the push.
+ - Stack-depth indicators start at 0 at the beginning of each block.
+ - Sequences of trees tied together with push and pop must be contiguous.
+   Arbitrary blocks can be placed in the middle of trees, but their return value
+   has to be consumed by some node in the tree.
+
+These rules reflect how the current wasm binary format works. If there are
+changes to wasm, these rules would change accordingly.
+
+
+## Operators with special syntax
+
+As mentioned earlier, basic arithmetic operators use an infix notation, some
+operators require explicit parentheses, and some operators use `?` to introduce
+boolean conditions. The following is a table of special syntax:
+
+
+## Control flow operators ([described here](https://github.com/WebAssembly/design/blob/master/AstSemantics.md))
+
+| Name | Syntax | Examples
+| ---- | ---- | ---- |
+| `block` | *label*: | `{ br $a a: }`
+| `loop` | `loop` *label* `{` … `}` | `loop $a { br $a }`
+| `if` | `if` (*expr*) `{` *expr** `}` | `if (0) { 1 }`
+| `if_else` | `if` (*expr*) `{` *expr** `} else {` *expr**`}` | `if (0) { 1 } else { 2 }`
+| `select` | `select` *expr*, *expr* ? *expr* | `select 1, 2 ? $x < $y`
+| `br` | `br` *label* | `br $a`
+| `br_if` | `br` *label* `?` *expr* | `br $a`, `br $a ? $x < $y`
+| `br_table` | `br_table [` *case-label* `,` … `] ,` *default-label* `,` *expr* | `br_table [$x, $y], $z, 0`
+
+(TODO: as above, are the `?`s too cute?)
+
+## Basic operators ([described here](https://github.com/WebAssembly/design/blob/master/AstSemantics.md#constants))
+
+| Name | Syntax | Example
+| ---- | ---- | ---- |
+| `i32.const` | … | `234`, `0xfff7`
+| `i64.const` | … | `234`, `0xfff7`
+| `f64.const` | … | `0.1p2`, `infinity`, `nan:0x789`
+| `f32.const` | … | `0.1p2`, `infinity`, `nan:0x789`
+| `get_local` | *name* | `$x + 1`
+| `set_local` | *name* `=` *expr* | `$x = 1`
+| `call` | `call` *name* `(`*expr* `,` … `)` | `call $min(0, 2)`
+| `call_import` | `call_import` *name* `(`*expr* `,` … `)` | `call_import $max(0, 2)`
+| `call_indirect` | `call_indirect` *signature-name* `[` *expr* `] (`*expr* `,` … `)` | `call_indirect $foo [1] $min(0, 2)`
+
+## Memory-related operators ([described here](https://github.com/WebAssembly/design/blob/master/AstSemantics.md#linear-memory-accesses))
+
+| Name | Syntax | Example
+| ---- | ---- | ---- |
+| *memory-immediate* | `[` *base-expression* `,` *offset* `]` | `[$base, 4]`
+| `i32.load8_s` | `i32.load8_s [` *base-expression* `, +` *offset-immediate* `]` | `i32.load8_s [$base, +4]`
+| `i32.load8_s` | `i32.load8_s [` *base-expression* `, +` *offset-immediate* `]:align=` *align* | `i32.load8_s [$base, +4]:align=2`
+| `i32.store8` | `i32.store8 [` *base-expression* `, +` *offset-immediate* `]`, *expr* | `i32.store8 [$base, +4], $value`
+| `i32.store8` | `i32.store8 [` *base-expression* `, +` *offset-immediate* `]:align=` *align* `,` *expr* | `i32.store8 [$base, +4]:align=2, $value`
+
+The other forms of `load` and `store` are similar.
+
+## Simple operators ([described here](AstSemantics#32-bit-integer-operators))
+
+| Name | Syntax |
+| ---- | ---- |
+| `i32.add` | … `+` …
+| `i32.sub` | … `-` …
+| `i32.mul` | … `*` …
+| `i32.div_s` | … `/s` …
+| `i32.div_u` | … `/u` …
+| `i32.rem_s` | … `%s` …
+| `i32.rem_u` | … `%u` …
+| `i32.and` | … `&` …
+| `i32.or` | … `|` …
+| `i32.xor` | … `^` …
+| `i32.shl` | … `<<` …
+| `i32.shr_u` | … `>>u` …
+| `i32.shr_s` | … `>>s` …
+| `i32.eq` | … `==` …
+| `i32.ne` | … `!=` …
+| `i32.lt_s` | … `<s` …
+| `i32.le_s` | … `<=s` …
+| `i32.lt_u` | … `<u` …
+| `i32.le_u` | … `<=u` …
+| `i32.gt_s` | … `>s` …
+| `i32.ge_s` | … `>=s` …
+| `i32.gt_u` | … `>u` …
+| `i32.ge_u` | … `>=u` …
+| `i32.eqz` | `!` …
+| `i64.add` | … `+` …
+| `i64.sub` | … `-` …
+| `i64.mul` | … `*` …
+| `i64.div_s` | … `/s` …
+| `i64.div_u` | … `/u` …
+| `i64.rem_s` | … `%s` …
+| `i64.rem_u` | … `%u` …
+| `i64.and` | … `&` …
+| `i64.or` | … `\|` …
+| `i64.xor` | … `^` …
+| `i64.shl` | … `<<` …
+| `i64.shr_u` | … `>>u` …
+| `i64.shr_s` | … `>>s` …
+| `i64.eq` | … `==` …
+| `i64.ne` | … `!=` …
+| `i64.lt_s` | … `<s` …
+| `i64.le_s` | … `<=s` …
+| `i64.lt_u` | … `<u` …
+| `i64.le_u` | … `<=u` …
+| `i64.gt_s` | … `>s` …
+| `i64.ge_s` | … `>=s` …
+| `i64.gt_u` | … `>u` …
+| `i64.ge_u` | … `>=u` …
+| `i64.eqz` | `!` …
+| `f32.add` | … `+` …
+| `f32.sub` | … `-` …
+| `f32.mul` | … `*` …
+| `f32.div` | … `/` …
+| `f32.neg` | `-` …
+| `f32.eq` | … `==` …
+| `f32.ne` | … `!=` …
+| `f32.lt` | … `<` …
+| `f32.le` | … `<=` …
+| `f32.gt` | … `>` …
+| `f32.ge` | … `>=` …
+| `f64.add` | … `+` …
+| `f64.sub` | … `-` …
+| `f64.mul` | … `*` …
+| `f64.div` | … `/` …
+| `f64.neg` | `-` …
+| `f64.eq` | … `==` …
+| `f64.ne` | … `!=` …
+| `f64.lt` | … `<` …
+| `f64.le` | … `<=` …
+| `f64.gt` | … `>` …
+| `f64.ge` | … `>=` …
+
+All other operators use their actual name in a prefix notation, such as
+`f32.sqrt …`.
+
+## Answers to anticipated questions
+
+Q: JS avoids sigils, and uses context-sensitive keywords to avoid trouble.
+   Can wasm do this?
+
+A: Sigils are more of a burden when writing code than reading code, and wasm
+   will mostly be written by compilers. And it's my subjective opinion that
+   it's better to give ourselves maximum flexibility to add new keywords in
+   the future without having to be tricky.
+
+
+Q: Why not let `br` be spelled `break` or `continue` when targeting block and
+   loop, respectively?
+
+A: The `br_table` construct has multiple labels, and there may be a mix of
+   forward and backward branches, so it isn't always possible to categorize
+   branches as forward or backward. Also, `br`, `br_if`, and `br_table` are
+   what we have in the spec, so using their actual names avoids needing
+   to special-case them.
+
+
+Q: Why not permit optional semicolons?
+
+A: We don't want people arguing over which way is better. If we don't forbid
+   semicolons, the next best option would be to require semicolons. I've
+   subjectively chosen to forbid semicolons for now.
+
 
 # Debug symbol integration
 

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -37,6 +37,13 @@ support more human-readable representations, but never at the cost of accurate r
 
 # Official Text Format
 
+## Warning: this is an experiment.
+
+This document has not been submitted to any official WebAssembly forum.
+It is not known at this time whether it ever will be, and if it is, it
+may be with significant changes.
+
+
 ## Philosophy:
 
  - Use JS-style sensibilities when there aren't reasons otherwise.

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -46,7 +46,7 @@ about syntax, but it differs from normal programming languages in numerous
 respects, so we don't fully trust our intuitions.
 
 So, we're sketching something up, and building a trial implementation of it in
-Firefox, so that we can try it out on real code in a real browser setting, to
+Firefox. This way, we can try it out on real code in a real browser setting, and
 see if it actually "works" in practice. Maybe we'll like it and propose it to
 the official WebAssembly project. Maybe it'll need changes. Or maybe it'll
 totally flop and we'll drop it and pursue something completely different!

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -88,15 +88,13 @@ may be with significant changes.
   function $fac-opt ($a:i64) : (i64) {
     var $x:i64
     $x = 1
-    {
-      br_if $end ? $a <s 2
-      loop $loop {
-        $x = $x * $a
-        $a = $a + -1
-        br_if $loop ? $a >s 1
-      }
-      $end:
+    br_if $end ? $a <s 2
+    loop $loop {
+      $x = $x * $a
+      $a = $a + -1
+      br_if $loop ? $a >s 1
     }
+  $end:
     $x
   }
 ```
@@ -274,15 +272,15 @@ nesting of `br_table` to be printed in a relatively flat manner:
 ```
   {
     br_table [$red, $orange, $yellow, $green], $default, $index
-    $red:
+  $red:
       // ...
-    $orange:
+  $orange:
       // ...
-    $yellow:
+  $yellow:
       // ...
-    $green:
+  $green:
       // ...
-    $default:
+  $default:
       // ...
   }
 ```

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -537,6 +537,16 @@ A: We don't want people arguing over which way is better. If we don't forbid
    subjectively chosen to forbid semicolons for now.
 
 
+Q: How about replacing push/pop with something more flexible?
+
+A: Push/pop as described here are meant to be a direct reflection of WebAssembly
+   itself. For example, it would be convenient to replace `push` with
+   something that would allow a value to be used multiple times. However,
+   push/pop are representing expression tree edges in WebAssembly, which
+   can only have a single definition and a single use. The way to use a value
+   multiple times in WebAssembly is to use `set_local` and `get_local`.
+
+
 # Debug symbol integration
 
 The binary format inherently strips names from functions, locals, globals, etc,


### PR DESCRIPTION
See [#697 in WebAssembly/design](https://github.com/WebAssembly/design/issues/697) for an introduction. **Note**: base branch is wrong; I don't think I can fix it here, so see #8 for the diff.

This PR is meant largely as an illustration; I know it's not likely to be merged. It includes three categories of changes to the initial strawman; the first two are prerequisites for the third, which is the real point of the PR.
## 1. Changes to eliminate ambiguity
- The original strawman uses a paren-free design for opcodes, so that presumably `i32.rotl $0, 8` is how you rotate by 8. This is not ambiguous for the proposed parser since all opcodes are keywords, but it is visually ambiguous to readers, who could easily see `call $foo(i32.rotl $0, 8, 9)` as a function that takes three arguments rather than two. So I propose
  1. Parens for most opcodes: `i32.rotl($0, 8)`
  2. Instead of `f32.store [5,+0], -0x0p0`, use `f32.store [5,+0] = -0x0p0`
  3. Instead of `br_table [$a, $b, $c], $default, $index`, use `br_table [a, b, c, default] : $index` (this particular syntax is LES-compatible, see below.)
  4. Instead of `br $exit, $i`, use `br exit => $i`, where `=> $i` is optional
  5. Similarly for `br_if`, use `br exit (if condition) => $i`
- Use a numeric suffix to distinguish `i64` from `i32` and `f64` from `f32`. Based on C/C++/C# I propose no required suffix for `f64` or `i32`, but to use `L` for `i64` and `f` for `f32` (`123L`, `12.0p+0f`). Another possibility would have been suffixes `i64` and `f32` as in Rust. **Note**: type inference is possible, e.g. `$x + 5` could infer that `5` is `f32` when `$x` is `f32`, but what about `3p+0 + 3p+0`? Since wasm is low-level, the text should be _allowed_ to specify the types, even if they _can_ be inferred (and I'd prefer not to require the entire opcode name).
## 2. Simplifying changes
- Instead of `call $foo(...)`, use simply `$foo(...)`.
- Instead of `call_import $foo(...)`, use `$$foo(...)`
- Instead of `call_indirect $sig [1] $min(0, 2)` - wait, what is the `[1]` for? I don't see it in the s-exprs I'm looking at. So, I propose `$min::$sig(0, 2)`, where `::` is a high-precedence operator. Having removed the `call_indirect` keyword, I think reversing the order will be more readable in case `$min` is a complex expression.
## 3. Changes to allow LES

I propose that the text format be compatible with [LES](http://loyc.net/les/) - as the PR text explains, not LES as it exists today, but as it will be when the MVP is launched. This gives the CG some freedom to make _some_ changes to LES and not others. Specifically, any elements that make sense _only_ in WebAssembly (e.g. keywords for wasm opcodes) would not be permitted, but changes such as tweaks to operator precedence, handling of semicolons, the grammar of LES "superexpressions", or the name used for "infinity", are fine.

The proposed goals of the text format are "match existing conventions on the Web (for example, curly braces, as in JavaScript and CSS)", and since LES is fairly JS-like language, I assert that any reasonable text format is straightforwardly modified to be LES-compatible. Here are the required changes:
- In LES, `$foo-loop` subtracts `loop` from `$foo`, so you need to write `$@foo-bar` to tell the parser that the hyphen is part of the identifier. However, this could be changed if people are strongly in favor of allowing dashes in identifiers. LES also allows any UTF-8 string as an identifier, even `@`\n\0`` (a newline character and a null character) or `@``` (the empty string). Similarly, `i32.reinterpret/f32` is changed to `i32.reinterpret'f32` to make clear it is not a division (`'` is legal in identifiers).
- In the original design, all the "rare" single-arg opcodes that don't use a special operator, such as `i32.popcnt $x`, do not need parentheses, but LES currently requires additional syntax: either `i32.popcnt($x)` or ``i32.popcnt` $x` (I prefer the first option.)
- `function $@fac-opt($a:i64) : i64`: the parens around i64 are (and must be) optional in LES.
- Understandably, `<s` and `>s` are not valid operator names, because in any language other than wasm, `r>s` should be parsed as `r > s`. LES operators must therefore consist of punctuation, and I selected `>` for signed and `|>` for unsigned. Unfortunately this turns out to be a little clumsy since we need `>|=` instead of `|>=` (this is explained in the PR), but LES does offer backquotes for making non-punctuation operators, so `$0`>s`$1` or `$0`>=u`$1` could be used instead.
- `var $x:i64` is changed to `$x:i64` because although the former syntax is legal in LES, it is redundant. Since LES is highly regular, using essentially the same syntax _everywhere_, if `$x:i64` is legal syntax in the formal argument list, it must also be legal in the function body.
- As a consequence, labels of the form `foo:` are not very practical since `:` is also a binary operator. Consider `foo: $x = 0`, which would be parsed as `(foo : $x) = 0`. So instead I've moved the colon to the start; `foo: $x = 0` would either have to be written on two lines, or on a single line as `:foo; $x = 0`.
- Currently, LES gives a syntax error for `function $foo () : i32`; the space before `(` must be removed; this is related to how LES manages to be a keyword-free language. However, if there's a lot of hate for this, I can eliminate the whitespace sensitivity (though something somewhere will have to be sacrificed).
- The `,` in `i32.store8 [$base, +4]:align=2, $value` is bad as mentioned above, while `:` and `=` are not ideal punctuation. There are a variety of alternatives but I picked `i32.store8 [$base, +4, align 2] = $value`.
- Sigils on labels are not really needed, since LES has no keywords that the labels could conflict with (future nullary opcodes could be written `opcode()` to ensure they do not clash with labels, as the latter cannot have arguments). **Note** there is no need for `$` on local variables either, but I didn't remove them since we obviously can't replace variables like `$0` with just `0`, so there was no immediate benefit. FYI, `@0` is how you write an identifier that begins with a digit in LES, in contrast to `$0` which is the prefix operator `$` applied to the literal `0`.

**Note**: I left the text as "The `$` sigil on function and variable names cleanly ensures that they never collide with wasm keywords, present or future." This is correct except for the word "keywords", since LES doesn't have keywords. Still, _collisions_ may be possible at least when it comes to function calls, since for example `loop({...})` means the same thing as `loop {...}` in LES, so if `loop` were a function and the `$` were not required, there would be a collision.

There are other, niggly issues that deserve mention, but this is getting long so I'll stop here and let you read the [rationales](https://github.com/WebAssembly/design/issues/697) if you haven't yet.
### TODOs

I have opinions about all the TODOs but I've left them out of the PR and also added my own TODO regarding whether or not semicolons should be required. I will just say that regarding the [precedence of `&|^`](http://www.lysator.liu.se/c/dmr-on-or.html), LES is spec'd to punt on that issue, by printing an error if you write an expression like `x & y == z`.
